### PR TITLE
Update dashboard styles

### DIFF
--- a/src/components/backtalk/Dashboard.tsx
+++ b/src/components/backtalk/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   Th,
   Tbody,
   Td,
+  Text,
   Button,
   Box,
   Center,
@@ -105,14 +106,16 @@ export const Dashboard = () => {
                 <Tr key={survey.id}>
                   <Td>
                     <Link href={`/backtalk/results/${survey.id}`}>
-                      {survey.title}
+                      <Text isTruncated maxW={64}>
+                        {survey.title}
+                      </Text>
                     </Link>
                   </Td>
                   <Td>
                     {(latestResponseBySurveyId?.[survey.id] &&
                       format(
                         latestResponseBySurveyId?.[survey.id],
-                        "eeee, MMMM d, yyyy 'at' H:mm  (z)",
+                        "MM/dd/yy '-' H:mm",
                       )) ??
                       'None'}
                   </Td>


### PR DESCRIPTION
- Truncate survey title once wider than max width {64}.
- Change date format to save space.